### PR TITLE
Removing the master and slave vocabulary

### DIFF
--- a/client/python/src/destination/Destination.py
+++ b/client/python/src/destination/Destination.py
@@ -71,7 +71,7 @@ class Destination(object):
             prop[constants.TIMEOUT] = str(queryInfo.timeout)
             prop[constants.TYPE] = "PUB"
             urls = self.client.getBroker(queryInfo.user, queryInfo.pwd, queryInfo.topic, queryInfo.only, prop)
-#            urls = "{\"sessionId\":\"8045f5cb0521c82598584f3151b1a1d5\",\"brokerserver\":[\"{\\\"master\\\":\\\"localhost:8888\\\",\\\"slave\\\":[]}\"]}"
+#            urls = "{\"sessionId\":\"8045f5cb0521c82598584f3151b1a1d5\",\"brokerserver\":[\"{\\\"main\\\":\\\"localhost:8888\\\",\\\"subordinate\\\":[]}\"]}"
             logger.debug("Urls from router: " + urls)
             return UrlDecoder(urls)
         except TException, e:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.